### PR TITLE
Univeral not null calculation; Input format autodetection; Targets dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ python3 -m pip install -r requirements.txt
 
 ## Running
 
+The modules can be run locally or in the Google Cloud (in this case, a `e2-highcpu-8` instance is recommended).
+
 ### Pre-pipeline run
 You will first need to collect the latest evidence string JSON files for all sources. This can be done using the [`platform-input-support`](https://github.com/opentargets/platform-input-support) module. The easiest way is to run it is through Docker.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ source env/bin/activate
 python3 metrics.py \
   --run-id 21.02.2-pre \
   --out data/21.02.2-pre.csv \
-  --evidence-pre-pipeline platform-input-support/output/evidence-files/
+  --evidence platform-input-support/output/evidence-files/
 ```
 
 ### Post-pipeline run
@@ -79,7 +79,7 @@ source env/bin/activate
 python3 metrics.py \
   --run-id 21.02.2-post \
   --out data/21.02.2-post.csv \
-  --evidence-post-pipeline post-pipeline/evidence \
+  --evidence post-pipeline/evidence \
   --evidence-failed post-pipeline/evidenceFailed \
   --associations-direct post-pipeline/associationByOverallDirect \
   --associations-indirect post-pipeline/associationByOverallIndirect \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ python3 metrics.py \
 First specify the ETL input and output roots. Note that there are two options for the output root depending on whether the script is being run on a completed release or on a snapshot (pick one option accordingly):
 ```bash
 export ETL_PARQUET_OUTPUT_ROOT=gs://ot-snapshots/etl/outputs/21.04.2/parquet  # For snapshots.
-export ETL_OUTPUT_ROOT=gs://open-targets-data-releases/21.04/output/etl-parquet  # For completed releases. 
+export ETL_PARQUET_OUTPUT_ROOT=gs://open-targets-data-releases/21.04/output/etl/parquet  # For completed releases.
 export ETL_INPUT_ROOT=gs://open-targets-data-releases/21.04/input
 ```
 
@@ -69,6 +69,7 @@ gsutil -m cp -r \
   ${ETL_PARQUET_OUTPUT_ROOT}/associationByOverallDirect \
   ${ETL_PARQUET_OUTPUT_ROOT}/associationByOverallIndirect \
   ${ETL_PARQUET_OUTPUT_ROOT}/diseases \
+  ${ETL_PARQUET_OUTPUT_ROOT}/targets \
   ${ETL_INPUT_ROOT}/annotation-files/chembl/chembl_*molecule*.jsonl \
   post-pipeline
 ```
@@ -84,5 +85,6 @@ python3 metrics.py \
   --associations-direct post-pipeline/associationByOverallDirect \
   --associations-indirect post-pipeline/associationByOverallIndirect \
   --diseases post-pipeline/diseases \
+  --targets post-pipeline/targets \
   --drugs post-pipeline/chembl_*molecule*.jsonl
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 Contains modules to calculate and visualise Open Targets release metrics.
 
-### Dependencies installation
+## Installation
+As system level dependencies, the modules require Python3 with the `venv` module and Java. In Ubuntu, they can be installed using `sudo apt install -y python3-venv openjdk-14-jre-headless`.
+
+After that, create and prepare the environment:
 ```bash
 python3 -m venv env
 source env/bin/activate
 python3 -m pip install -r requirements.txt
 ```
+
+## Running
 
 ### Pre-pipeline run
 You will first need to collect the latest evidence string JSON files for all sources. This can be done using the [`platform-input-support`](https://github.com/opentargets/platform-input-support) module. The easiest way is to run it is through Docker.

--- a/metrics.py
+++ b/metrics.py
@@ -93,9 +93,16 @@ def not_null_fields_count(df: DataFrame, var_name: str, group_by_datasource: boo
     # Clean column names.
     df_cleaned = df_aggregated.toDF(*(c.replace('.', '_') for c in df_aggregated.columns))
     # Wide to long format.
-    melted = melt(df_cleaned, id_vars=['datasourceId'] if group_by_datasource else [], var_name='field',
-                  value_vars=field_list, value_name='count')
-    melted = melted.withColumn('variable', f.lit(var_name))
+    melted = (
+        melt(
+            df=df_cleaned,
+            id_vars=['datasourceId'] if group_by_datasource else [],
+            var_name='field',
+            value_vars=field_list,
+            value_name='count'
+        )
+        .withColumn('variable', f.lit(var_name))
+    )
     if not group_by_datasource:
         melted = melted.withColumn('datasourceId', f.lit('all'))
     return melted
@@ -103,7 +110,8 @@ def not_null_fields_count(df: DataFrame, var_name: str, group_by_datasource: boo
 
 def evidence_distinct_fields_count(
         df: DataFrame,
-        var_name: str) -> DataFrame:
+        var_name: str
+) -> DataFrame:
     """Count unique values in variable (e.g. targetId) and datasource."""
 
     # flatten dataframe schema

--- a/metrics.py
+++ b/metrics.py
@@ -34,8 +34,11 @@ def flatten(schema, prefix=None):
 
 def melt(
         df: DataFrame,
-        id_vars: Iterable[str], value_vars: Iterable[str],
-        var_name: str = 'variable', value_name: str = 'value') -> DataFrame:
+        id_vars: Iterable[str],
+        value_vars: Iterable[str],
+        var_name: str = 'variable',
+        value_name: str = 'value'
+) -> DataFrame:
     """Convert :class:`DataFrame` from wide to long format."""
 
     # Create array<struct<variable: str, value: ...>>
@@ -53,7 +56,8 @@ def melt(
 
 def document_total_count(
         df: DataFrame,
-        var_name: str) -> DataFrame:
+        var_name: str
+) -> DataFrame:
     """Count total documents."""
     out = df.groupBy().count().alias('count')
     out = out.withColumn('datasourceId', f.lit('all'))
@@ -65,7 +69,8 @@ def document_total_count(
 def document_count_by(
         df: DataFrame,
         column: str,
-        var_name: str) -> DataFrame:
+        var_name: str
+) -> DataFrame:
     """Count documents by grouping column."""
     out = df.groupBy(column).count().alias('count')
     out = out.withColumn('variable', f.lit(var_name))
@@ -73,7 +78,11 @@ def document_count_by(
     return out
 
 
-def not_null_fields_count(df: DataFrame, var_name: str, group_by_datasource: bool) -> DataFrame:
+def not_null_fields_count(
+        df: DataFrame,
+        var_name: str,
+        group_by_datasource: bool
+) -> DataFrame:
     """Count number of not null values for each field in the dataframe. If `group_by_datasource` is enabled, the
     calculation is performed separately for every datasource in the `datasourceId` column."""
     # Flatten the dataframe schema.

--- a/metrics.py
+++ b/metrics.py
@@ -224,8 +224,11 @@ def parse_args():
         '--diseases', required=False, metavar='<path>', type=str, help=(
             'Disease information from ${ETL_PARQUET_OUTPUT_ROOT}/diseases.'))
     dataset_arguments.add_argument(
+        '--targets', required=False, metavar='<path>', type=str, help=(
+            'Targets dataset from ${ETL_PARQUET_OUTPUT_ROOT}/targets.'))
+    dataset_arguments.add_argument(
         '--drugs', required=False, metavar='<path>', type=str, help=(
-            'ChEMBL dataset directory from ${ETL_INPUT_ROOT}/annotation-files/chembl/chembl_*molecule*.jsonl.'))
+            'ChEMBL dataset from ${ETL_INPUT_ROOT}/annotation-files/chembl/chembl_*molecule*.jsonl.'))
 
     # General optional arguments.
     parser.add_argument(
@@ -266,6 +269,7 @@ def main(args):
     associations_direct = read_path_if_provided(spark, args.associations_direct)
     associations_indirect = read_path_if_provided(spark, args.associations_indirect)
     diseases = read_path_if_provided(spark, args.diseases)
+    targets = read_path_if_provided(spark, args.targets)
     drugs = read_path_if_provided(spark, args.drugs)
 
     datasets = []
@@ -369,15 +373,19 @@ def main(args):
         ])
 
     if diseases:
-        # TODO: diseases.
         logging.info(f'Running metrics from {args.diseases}.')
         datasets.extend([
             document_total_count(diseases, 'diseasesTotalCount'),
             not_null_fields_count(diseases, 'diseasesNotNullCount', group_by_datasource=False),
         ])
 
+    if targets:
+        logging.info(f'Running metrics from {args.targets}.')
+        datasets.extend([
+            document_total_count(targets, 'targetsTotalCount'),
+        ])
+
     if drugs:
-        # TODO: drugs.
         logging.info(f'Running metrics from {args.drugs}.')
         datasets.extend([
             document_total_count(drugs, 'drugsTotalCount'),


### PR DESCRIPTION
* Universal not null calculation
* Rewrote the input format autodetection and the `--evidence` handling
* Amended the list of system level dependencies and added suggestions for running in Google Cloud.
* Added the targets dataset

As we discussed during the stand-up, there's no need in the distinct count calculation for anything other than the evidence datasets.